### PR TITLE
test-image-stitch: calibration data move to FISHEYE_CONFIG_PATH dir

### DIFF
--- a/tests/test-soft-image.cpp
+++ b/tests/test-soft-image.cpp
@@ -45,8 +45,6 @@
 
 #define XCAM_TEST_MAX_STR_SIZE 1024
 
-#define FISHEYE_CONFIG_PATH "./"
-
 #define MAP_WIDTH 3
 #define MAP_HEIGHT 4
 
@@ -748,9 +746,11 @@ int main (int argc, char *argv[])
         XCAM_ASSERT (stitcher.ptr ());
 
         CameraInfo cam_info[4];
-        const char *fisheye_config_path = getenv ("FISHEYE_CONFIG_PATH");
+        const char *fisheye_config_path = getenv (FISHEYE_CONFIG_ENV_VAR);
         if (!fisheye_config_path)
             fisheye_config_path = FISHEYE_CONFIG_PATH;
+
+        XCAM_LOG_INFO ("calibration config path:%s", XCAM_STR (fisheye_config_path));
 
         for (uint32_t i = 0; i < camera_count; ++i) {
             if (parse_camera_info (fisheye_config_path, i, cam_info[i], camera_count) != 0) {

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -60,6 +60,8 @@
 #define DEFAULT_HYBRID_3A_LIB "/usr/lib/xcam/plugins/3a/libxcam_3a_hybrid.so"
 #define DEFAULT_SMART_ANALYSIS_LIB_DIR "/usr/lib/xcam/plugins/smart"
 
+#define FISHEYE_CONFIG_PATH "./calib_params/"
+#define FISHEYE_CONFIG_ENV_VAR "FISHEYE_CONFIG_PATH"
 
 #define FPS_CALCULATION(objname, count) XCAM_STATIC_FPS_CALCULATION(objname, count)
 


### PR DESCRIPTION
 * add environment variable FISHEYE_CONFIG_PATH for
   calibration path.
 * add option --save-top-view for top-view video record,
   default No.
 * add option --save-free-view for free-point-view video
   record, default No.

 * test cmdline: last-line enabled top-view and free-view.
   $ export FISHEYE_CONFIG_PATH=/etc/xcam/calibration
   $ ./test-image-stitching --input cam0_1280x800.nv12 \
     --input cam1_1280x800.nv12 --input cam2_1280x800.nv12 \
     --input cam3_1280x800.nv12 --output stitch-out.mp4 \
     --input-w 1280 --input-h 800 --output-w 1920 --output-h 640 \
     --scale-mode local --enable-fisheyemap --res-mode 1080p4 \
     --surround-mode bowl --fm-ocl false --framerate 30.0 \
     --save true --fisheye-num 4 --all-in-one false \
     --save-top-view --save-free-view