### PR TITLE
soft-stitch: support 8k(3-cameras) sphere stitching

### DIFF
--- a/modules/soft/soft_stitcher.cpp
+++ b/modules/soft/soft_stitcher.cpp
@@ -241,6 +241,17 @@ get_fm_config (StitchResMode res_mode)
 #endif
         break;
     }
+    case StitchRes8K3Cams: {
+        config.stitch_min_width = 136;
+        config.min_corners = 4;
+        config.offset_factor = 0.95f;
+        config.delta_mean_offset = 256.0f;
+        config.recur_offset_error = 4.0f;
+        config.max_adjusted_offset = 24.0f;
+        config.max_valid_offset_y = 20.0f;
+        config.max_track_error = 8.0f;
+        break;
+    }
     default:
         XCAM_LOG_DEBUG ("unknown reslution mode (%d)", res_mode);
         break;
@@ -267,6 +278,24 @@ get_stitch_info (StitchResMode res_mode)
         stitch_info.fisheye_info[1].wide_angle = 202.8f;
         stitch_info.fisheye_info[1].radius = 480.0f;
         stitch_info.fisheye_info[1].rotate_angle = 89.7f;
+        break;
+    }
+    case StitchRes8K3Cams: {
+        stitch_info.fisheye_info[0].center_x = 1920.0f;
+        stitch_info.fisheye_info[0].center_y = 1440.0f;
+        stitch_info.fisheye_info[0].wide_angle = 200.0f;
+        stitch_info.fisheye_info[0].radius = 1984.0f;
+        stitch_info.fisheye_info[0].rotate_angle = 90.2f;
+        stitch_info.fisheye_info[1].center_x = 1920.0f;
+        stitch_info.fisheye_info[1].center_y = 1440.0f;
+        stitch_info.fisheye_info[1].wide_angle = 200.0f;
+        stitch_info.fisheye_info[1].radius = 1984.0f;
+        stitch_info.fisheye_info[1].rotate_angle = 90.2f;
+        stitch_info.fisheye_info[2].center_x = 1920.0f;
+        stitch_info.fisheye_info[2].center_y = 1440.0f;
+        stitch_info.fisheye_info[2].wide_angle = 200.0f;
+        stitch_info.fisheye_info[2].radius = 1984.0f;
+        stitch_info.fisheye_info[2].rotate_angle = 90.0f;
         break;
     }
     default:

--- a/tests/test-surround-view.cpp
+++ b/tests/test-surround-view.cpp
@@ -421,7 +421,7 @@ static void usage(const char* arg0)
             "\t--topview-h         optional, output height, default: 720\n"
             "\t--fisheye-num       optional, the number of fisheye lens, default: 4\n"
             "\t--res-mode          optional, image resolution mode\n"
-            "\t                    select from [1080p2cams/1080p4cams], default: 1080p4cams\n"
+            "\t                    select from [1080p2cams/1080p4cams/8k3cams], default: 1080p4cams\n"
             "\t--dewarp-mode       optional, fisheye dewarp mode, select from [sphere/bowl], default: bowl\n"
             "\t--scale-mode        optional, scaling mode for geometric mapping,\n"
             "\t                    select from [singleconst/dualconst/dualcurve], default: singleconst\n"
@@ -541,6 +541,8 @@ int main (int argc, char *argv[])
                 res_mode = StitchRes1080P2Cams;
             else if (!strcasecmp (optarg, "1080p4cams"))
                 res_mode = StitchRes1080P4Cams;
+            else if (!strcasecmp (optarg, "8k3cams"))
+                res_mode = StitchRes8K3Cams;
             else {
                 XCAM_LOG_ERROR ("incorrect resolution mode");
                 return -1;
@@ -650,7 +652,8 @@ int main (int argc, char *argv[])
     printf ("topview width:\t\t%d\n", topview_width);
     printf ("topview height:\t\t%d\n", topview_height);
     printf ("fisheye number:\t\t%d\n", fisheye_num);
-    printf ("resolution mode:\t%s\n", res_mode == StitchRes1080P2Cams ? "1080p2cams" : "1080p4cams");
+    printf ("resolution mode:\t%s\n", res_mode == StitchRes1080P2Cams ? "1080p2cams" :
+            (res_mode == StitchRes1080P4Cams ? "1080p4cams" : "8k3cams"));
     printf ("dewarp mode: \t\t%s\n", dewarp_mode == DewarpSphere ? "sphere" : "bowl");
     printf ("scaling mode:\t\t%s\n", (scale_mode == ScaleSingleConst) ? "singleconst" :
             ((scale_mode == ScaleDualConst) ? "dualconst" : "dualcurve"));
@@ -724,8 +727,13 @@ int main (int argc, char *argv[])
     stitcher->set_fm_mode (fm_mode);
 
     if (dewarp_mode == DewarpSphere) {
-        float viewpoints_range[] = {202.8f, 202.8f};
-        stitcher->set_viewpoints_range (viewpoints_range);
+        if (res_mode == StitchRes1080P2Cams) {
+            float viewpoints_range[] = {202.8f, 202.8f};
+            stitcher->set_viewpoints_range (viewpoints_range);
+        } else if (res_mode == StitchRes8K3Cams) {
+            float viewpoints_range[] = {144.0f, 144.0f, 144.0f};
+            stitcher->set_viewpoints_range (viewpoints_range);
+        }
     } else {
         float viewpoints_range[] = {64.0f, 160.0f, 64.0f, 160.0f};
         stitcher->set_viewpoints_range (viewpoints_range);

--- a/xcore/interface/stitcher.h
+++ b/xcore/interface/stitcher.h
@@ -39,6 +39,7 @@ enum StitchResMode {
     StitchRes1080P2Cams,
     StitchRes1080P4Cams,
     StitchRes4K2Cams,
+    StitchRes8K3Cams,
     StitchRes8K6Cams
 };
 


### PR DESCRIPTION
 * test cmdline:
   $ test-surround-view --module soft --output output.mp4 \
     --input input0.nv12 --input input1.nv12 --input input2.nv12 \
     --fisheye-num 3 --res-mode 8k3cams --dewarp-mode sphere \
     --scale-mode dualconst --frame-mode multi --fm-mode cluster \
     --in-w 3840 --in-h 2880 --out-w 7680 --out-h 3840 --save true \
     --save-topview false --loop 1