### PR TITLE
modules/vulkan: point to correct location of spv shaders

### DIFF
--- a/modules/vulkan/Makefile.am
+++ b/modules/vulkan/Makefile.am
@@ -5,7 +5,7 @@ XCAM_VK_CXXFLAGS = \
     $(LIBVULKAN_CFLAGS)           \
     -I$(top_srcdir)/xcore         \
     -I$(top_srcdir)/modules       \
-    -I$(top_builddir)/shaders/spv \
+    -I$(top_srcdir)/shaders/spv \
     $(NULL)
 
 XCAM_VK_LIBS = \


### PR DESCRIPTION
They are not generated and are present in source directory. Leads to failures when builddir != srcdir:

| compilation terminated.
| make[3]: *** [libxcam_vulkan_la-vk_geomap_handler.lo] Error 1
| make[3]: *** Waiting for unfinished jobs....
| ../../../git/modules/vulkan/vk_copy_handler.cpp:80:10: fatal error: shader_copy.comp.spv: No such file or directory
|    80 | #include "shader_copy.comp.spv"

Signed-off-by: Anuj Mittal <anuj.mittal@intel.com>