### PR TITLE
test-soft-image.cpp: fix header path

### DIFF
--- a/tests/test-soft-image.cpp
+++ b/tests/test-soft-image.cpp
@@ -28,7 +28,7 @@
 #include <interface/blender.h>
 #include <interface/geo_mapper.h>
 #include <interface/stitcher.h>
-#include <xcore/fisheye_dewarp.h>
+#include <fisheye_dewarp.h>
 
 #define MAP_WIDTH 3
 #define MAP_HEIGHT 4


### PR DESCRIPTION
throw compilation error:
 | ../../git/tests/test-soft-image.cpp:31:10: fatal error: xcore/fisheye_dewarp.h: No such file or directory
|    31 | #include <xcore/fisheye_dewarp.h>
|       |          ^~~~~~~~~~~~~~~~~~~~~~~~
| compilation terminated.

TEST_BASE_CXXFLAGS already includes -I$(top_srcdir)/xcore

Ref: https://github.com/intel/libxcam/blob/1.4.0/tests/Makefile.am#L48

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>