### PR TITLE
Fix build with Vulkan 1.2.140 and later

### DIFF
--- a/modules/vulkan/vk_instance.cpp
+++ b/modules/vulkan/vk_instance.cpp
@@ -131,14 +131,14 @@ VKInstance::query_physical_info ()
     dev_num = XCAM_MIN (dev_num, MAX_DEV_NUM);
     vkEnumeratePhysicalDevices (_instance_id, &dev_num, devs);
 
-    VkPhysicalDevice gpu_dev[VK_PHYSICAL_DEVICE_TYPE_RANGE_SIZE] = {};
+    VkPhysicalDevice gpu_dev[VK_PHYSICAL_DEVICE_TYPE_CPU + 1] = {};
 
     VkPhysicalDeviceProperties dev_prop;
     for (uint32_t i = 0; i < dev_num; ++i) {
         vkGetPhysicalDeviceProperties (devs[i], &dev_prop);
 
-        if (dev_prop.deviceType < VK_PHYSICAL_DEVICE_TYPE_BEGIN_RANGE ||
-                dev_prop.deviceType > VK_PHYSICAL_DEVICE_TYPE_END_RANGE) {
+        if (dev_prop.deviceType < VK_PHYSICAL_DEVICE_TYPE_OTHER ||
+                dev_prop.deviceType > VK_PHYSICAL_DEVICE_TYPE_CPU) {
             continue;
         }
         if (gpu_dev[dev_prop.deviceType]) {


### PR DESCRIPTION
1.2.140 removed the various _BEGIN_RANGE, _END_RANGE
and _RANGE_SIZE macros, see e.g.
https://gitlab.freedesktop.org/mesa/mesa/-/commit/b0cb38f36085ccee6e71b6e50cb4f094d7f03c58#b04a2be508b96c4286a9f20523ba531cd4f7176a_1050_1032