### PR TITLE
support compile avx512 with non-avx512 workstation e.g. CI build

### DIFF
--- a/m4/xcam-utils.m4
+++ b/m4/xcam-utils.m4
@@ -130,7 +130,8 @@ AC_DEFUN([XCAM_CHECK_AVX512],
     AS_IF([test "x$1" = "xyes"],
         [
             count=`grep -c avx512 /proc/cpuinfo`
-            AS_IF([test $count -gt 0], [$2], [AC_MSG_ERROR(the processor does not support AVX512 instructions)])
+            AS_IF([test $count -gt 0], [], [AC_MSG_WARN(the processor does not support AVX512 instructions)])
+            [$2]
         ],
         [$3])
 ])


### PR DESCRIPTION
if the workstation cannot support avx512, let XCAM_CHECK_AVX512
report warning and continue building, insteadof error and stop
building, in order to support CI build

Signed-off-by: Tiger Meng <xiao.xi.meng@intel.com>