### PR TITLE
Implement conversion from equirectangular projection to cubemap

### DIFF
--- a/tests/test-surround-view.cpp
+++ b/tests/test-surround-view.cpp
@@ -315,7 +315,7 @@ create_topview_mapper (
 }
 
 static XCamReturn
-remap_topview_buf (const SmartPtr<SVStream> &stitch, const SmartPtr<SVStream> &topview)
+remap_buf (const SmartPtr<SVStream> &stitch, const SmartPtr<SVStream> &topview)
 {
     const SmartPtr<GeoMapper> mapper = topview->get_mapper();
     XCAM_ASSERT (mapper.ptr ());
@@ -375,12 +375,12 @@ write_image (
         write_out_image (outs[out_config.stitch_index], frame_num);
 
     if (out_config.save_topview) {
-        remap_topview_buf (outs[out_config.stitch_index], outs[out_config.topview_index]);
+        remap_buf (outs[out_config.stitch_index], outs[out_config.topview_index]);
         write_out_image (outs[out_config.topview_index], frame_num);
     }
 
     if (out_config.save_cubemap) {
-        remap_topview_buf (outs[out_config.stitch_index], outs[out_config.cubemap_index]);
+        remap_buf (outs[out_config.stitch_index], outs[out_config.cubemap_index]);
         write_out_image (outs[out_config.cubemap_index], frame_num);
     }
 

--- a/xcore/interface/stitcher.h
+++ b/xcore/interface/stitcher.h
@@ -360,6 +360,21 @@ private:
     float             _max_topview_length_mm;
 };
 
+class CubeMapModel {
+public:
+    typedef std::vector<PointFloat2> PointMap;
+
+public:
+    CubeMapModel (const uint32_t image_width, const uint32_t image_height);
+    bool get_cubemap_rect_map(
+        PointMap &texture_points,
+        uint32_t res_width,
+        uint32_t res_height);
+
+private:
+    uint32_t _erp_img_width, _erp_img_height;
+};
+
 }
 
 #endif //XCAM_INTERFACE_STITCHER_H

--- a/xcore/interface/stitcher.h
+++ b/xcore/interface/stitcher.h
@@ -365,7 +365,7 @@ public:
     typedef std::vector<PointFloat2> PointMap;
 
 public:
-    CubeMapModel (const uint32_t image_width, const uint32_t image_height);
+    CubeMapModel (uint32_t image_width, uint32_t image_height);
     bool get_cubemap_rect_map(
         PointMap &texture_points,
         uint32_t res_width,


### PR DESCRIPTION
Conversion is implemented by reusing geomap code, which is used at least for topview generation. New code calculates remap matrix and applies it with any supported geomap module: soft, gles or vulkan.

Usage example is provided in test-surround-view.

This pull request is part of Google Summer of Code project: https://summerofcode.withgoogle.com/projects/#4637812755791872