### PR TITLE
Fix multiple definitions of XCam::ShaderID (ODR violation)

### DIFF
--- a/modules/gles/gl_fastmap_blender.cpp
+++ b/modules/gles/gl_fastmap_blender.cpp
@@ -24,12 +24,6 @@
 
 namespace XCam {
 
-enum ShaderID {
-    ShaderFastmapBlendY = 0,
-    ShaderFastmapBlendUVNV12,
-    ShaderFastmapBlendUVYUV420
-};
-
 static const GLShaderInfo shaders_info[] = {
     {
         GL_COMPUTE_SHADER,
@@ -52,6 +46,12 @@ static const GLShaderInfo shaders_info[] = {
 };
 
 namespace GLFastmapBlendPriv {
+
+enum ShaderID {
+    ShaderFastmapBlendY = 0,
+    ShaderFastmapBlendUVNV12,
+    ShaderFastmapBlendUVYUV420
+};
 
 class Impl
 {

--- a/modules/gles/gl_geomap_handler.cpp
+++ b/modules/gles/gl_geomap_handler.cpp
@@ -27,14 +27,6 @@
 
 namespace XCam {
 
-enum ShaderID {
-    ShaderComMapNV12 = 0,    // NV12 common mapping
-    ShaderComMapYUV420,      // YUV420 common mapping
-    ShaderFastMapY,          // Y planar fast mapping
-    ShaderFastMapUVNV12,     // NV12 UV planar fast mapping
-    ShaderFastMapUVYUV420    // YUV420 UV planar fast mapping
-};
-
 static const GLShaderInfo shaders_info[] = {
     {
         GL_COMPUTE_SHADER,
@@ -69,6 +61,14 @@ static const GLShaderInfo shaders_info[] = {
 };
 
 namespace GLGeoMapPriv {
+
+enum ShaderID {
+    ShaderComMapNV12 = 0,    // NV12 common mapping
+    ShaderComMapYUV420,      // YUV420 common mapping
+    ShaderFastMapY,          // Y planar fast mapping
+    ShaderFastMapUVNV12,     // NV12 UV planar fast mapping
+    ShaderFastMapUVYUV420    // YUV420 UV planar fast mapping
+};
 
 class ComMap
 {


### PR DESCRIPTION
The IDs are only required inside the respective private namespaces, so
move it. This matches e.g. gl_blender.cpp and vk_blender.cpp.