### PR TITLE
fake_v4l2_device.h: fix narrowing warning

### DIFF
--- a/xcore/base/xcam_common.h
+++ b/xcore/base/xcam_common.h
@@ -75,7 +75,7 @@ void xcam_free (void *ptr);
   * return, 0 successfully
   *            else, check errno
   */
-int xcam_device_ioctl (int fd, int cmd, void *arg);
+int xcam_device_ioctl (int fd, uint32_t cmd, void *arg);
 const char *xcam_fourcc_to_string (uint32_t fourcc);
 
 void xcam_set_log (const char* file_name);

--- a/xcore/fake_v4l2_device.h
+++ b/xcore/fake_v4l2_device.h
@@ -33,7 +33,7 @@ public:
         : V4l2Device ("/dev/null")
     {}
 
-    int io_control (int cmd, void *arg)
+    int io_control (uint32_t cmd, void *arg)
     {
         XCAM_UNUSED (arg);
 

--- a/xcore/v4l2_device.cpp
+++ b/xcore/v4l2_device.cpp
@@ -185,7 +185,7 @@ V4l2Device::close ()
 }
 
 int
-V4l2Device::io_control (int cmd, void *arg)
+V4l2Device::io_control (uint32_t cmd, void *arg)
 
 {
     if (_fd <= 0)

--- a/xcore/v4l2_device.h
+++ b/xcore/v4l2_device.h
@@ -104,7 +104,7 @@ public:
     XCamReturn queue_buffer (SmartPtr<V4l2Buffer> &buf);
 
     // use as less as possible
-    virtual int io_control (int cmd, void *arg);
+    virtual int io_control (uint32_t cmd, void *arg);
 
 protected:
 

--- a/xcore/xcam_common.cpp
+++ b/xcore/xcam_common.cpp
@@ -53,7 +53,7 @@ void xcam_free(void *ptr)
         free (ptr);
 }
 
-int xcam_device_ioctl (int fd, int cmd, void *arg)
+int xcam_device_ioctl (int fd, uint32_t cmd, void *arg)
 {
     int ret = 0;
     int tried_time = 0;


### PR DESCRIPTION
Use uint32_t instead of int for IOCTLs commands.

Warning log:
| ../../../git/xcore/fake_v4l2_device.h: In member function 'virtual int XCam::FakeV4l2Device::io_control(int, void*)':
| ../../../git/xcore/fake_v4l2_device.h:42:14: error: narrowing conversion of '3225441794' from 'long unsigned int' to 'int' [-Wnarrowing]
|    42 |         case VIDIOC_ENUM_FMT:
|       |              ^~~~~~~~~~~~~~~
| make[4]: *** [Makefile:685: libgstxcamsrc_la-gstxcamsrc.lo] Error 1

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>