### PR TITLE
gl-stitch: support import input dma buffer & export output dma buffer

### DIFF
--- a/capi/ctxs/context_stitch.cpp
+++ b/capi/ctxs/context_stitch.cpp
@@ -248,7 +248,7 @@ StitchContext::create_buf_pool (StitchModule module)
         pool = new SoftVideoBufAllocator ();
     } else if (module == StitchGLES) {
 #if HAVE_GLES
-        SmartPtr<EGLBase> egl = new EGLBase ();
+        SmartPtr<EGLBase> egl = EGLBase::instance ();
         XCAM_ASSERT (egl.ptr ());
 
         XCAM_FAIL_RETURN (ERROR, egl->init (), XCAM_RETURN_ERROR_MEM, "init EGL failed");

--- a/modules/gles/Makefile.am
+++ b/modules/gles/Makefile.am
@@ -24,6 +24,7 @@ endif
 xcam_gles_sources = \
     gles_std.cpp           \
     gl_buffer.cpp          \
+    gl_texture.cpp         \
     gl_program.cpp         \
     gl_sync.cpp            \
     gl_shader.cpp          \
@@ -34,6 +35,7 @@ xcam_gles_sources = \
     gl_image_shader.cpp    \
     gl_image_handler.cpp   \
     gl_copy_handler.cpp    \
+    gl_dma_buffer_handler.cpp \
     gl_geomap_handler.cpp  \
     gl_blender.cpp         \
     gl_fastmap_blender.cpp \

--- a/modules/gles/egl/egl_base.h
+++ b/modules/gles/egl/egl_base.h
@@ -29,14 +29,20 @@
 #include <unistd.h>
 #endif
 
+#include <xcam_mutex.h>
+
 namespace XCam {
+
+class GLTexture;
+class VideoBuffer;
 
 class EGLBase {
 public:
-    explicit EGLBase ();
     ~EGLBase ();
+    static SmartPtr<EGLBase> instance ();
 
     bool init (const char* node_name = NULL);
+    bool is_inited () const;
 
     bool get_display (const char *node_name, EGLDisplay &display);
     bool get_display (NativeDisplayType native_display, EGLDisplay &display);
@@ -57,7 +63,24 @@ public:
     bool destroy_surface (EGLDisplay display, EGLSurface &surface);
     bool terminate (EGLDisplay display);
 
+    EGLImage create_image (int dmabuf_fd,
+                           EGLuint64KHR modifiers,
+                           uint32_t width,
+                           uint32_t height,
+                           EGLint stride,
+                           EGLint offset,
+                           int fourcc);
+
+    bool destroy_image (EGLImage image);
+
+    SmartPtr<VideoBuffer> export_dma_buffer (const SmartPtr<GLTexture>& gl_texture);
+
 private:
+    EGLBase ();
+
+private:
+    static SmartPtr<EGLBase>  _instance;
+    static Mutex      _instance_mutex;
     EGLDisplay        _display;
     EGLContext        _context;
     EGLSurface        _surface;
@@ -66,6 +89,8 @@ private:
     gbm_device        *_gbm_device;
     int32_t           _device;
 #endif
+    bool              _inited;
+
 };
 
 }

--- a/modules/gles/egl/egl_utils.h
+++ b/modules/gles/egl/egl_utils.h
@@ -21,8 +21,13 @@
 #ifndef XCAM_EGL_UTILS_H
 #define XCAM_EGL_UTILS_H
 
+#define EGL_EGLEXT_PROTOTYPES
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
+
+#define GL_GLEXT_PROTOTYPES
+#include <GL/gl.h>
+
 #include <xcam_std.h>
 
 namespace XCam {

--- a/modules/gles/gl_command.cpp
+++ b/modules/gles/gl_command.cpp
@@ -20,6 +20,7 @@
 
 #include "gl_command.h"
 #include "gl_buffer.h"
+#include "gl_texture.h"
 
 namespace XCam {
 
@@ -258,6 +259,31 @@ GLCmdBindBufRange::run (GLuint program)
     XCAM_FAIL_RETURN (
         ERROR, ret == XCAM_RETURN_NO_ERROR, ret,
         "GLCmdBindBufRange failed, idx:%d", _index);
+
+    return XCAM_RETURN_NO_ERROR;
+}
+
+GLCmdBindTexture::GLCmdBindTexture (
+    const SmartPtr<GLTexture> &texture, uint32_t index)
+    : _index (index)
+{
+    XCAM_ASSERT (texture.ptr ());
+    _texture = texture;
+}
+
+GLCmdBindTexture::~GLCmdBindTexture ()
+{
+}
+
+XCamReturn
+GLCmdBindTexture::run (GLuint program)
+{
+    XCAM_UNUSED (program);
+
+    XCamReturn ret = _texture->bind_image (_index);
+    XCAM_FAIL_RETURN (
+        ERROR, ret == XCAM_RETURN_NO_ERROR, ret,
+        "GLCmdBindTexture failed, idx:%d", _index);
 
     return XCAM_RETURN_NO_ERROR;
 }

--- a/modules/gles/gl_command.h
+++ b/modules/gles/gl_command.h
@@ -168,6 +168,7 @@ private:
 };
 
 class GLBuffer;
+class GLTexture;
 
 class GLCmdBindBufBase
     : public GLCommand
@@ -201,6 +202,23 @@ private:
     uint32_t                  _size;
 };
 
+class GLCmdBindTexture
+    : public GLCommand
+{
+public:
+    GLCmdBindTexture (const SmartPtr<GLTexture> &texture, uint32_t index);
+    virtual ~GLCmdBindTexture ();
+
+    virtual XCamReturn run (GLuint program);
+
+private:
+    SmartPtr<GLTexture>       _texture;
+    uint32_t                  _index;
+    uint32_t                  _offset;
+    uint32_t                  _size;
+};
+
 }
 
 #endif // XCAM_GL_COMMAND_H
+

--- a/modules/gles/gl_dma_buffer_handler.cpp
+++ b/modules/gles/gl_dma_buffer_handler.cpp
@@ -1,0 +1,368 @@
+/*
+ * gl_dma_buffer_handler.cpp - gl DMA buffer handler implementation
+ *
+ *  Copyright (c) 2022 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Zong Wei <wei.zong@intel.com>
+ */
+
+#include "gl_dma_buffer_handler.h"
+#include "gl_utils.h"
+#include "gl_sync.h"
+
+#define INVALID_INDEX (uint32_t)(-1)
+
+namespace XCam {
+
+static const GLShaderInfo shaders_info[] = {
+    {
+        GL_COMPUTE_SHADER,
+        "shader_copy_tex_to_ssbo",
+#include "shader_copy_tex_to_ssbo.comp.slx"
+        , 0
+    },
+    {
+        GL_COMPUTE_SHADER,
+        "shader_copy_ssbo_to_tex",
+#include "shader_copy_ssbo_to_tex.comp.slx"
+        , 0
+    }
+};
+
+namespace GLDmaBufferPriv {
+
+static SmartPtr<GLImageShader>
+create_shader (ShaderID id, const char *prog_name)
+{
+    SmartPtr<GLImageShader> shader = new GLImageShader (shaders_info[id].name);
+    XCAM_ASSERT (shader.ptr ());
+
+    XCamReturn ret = shader->create_compute_program (shaders_info[id], prog_name);
+    XCAM_FAIL_RETURN (
+        ERROR, ret == XCAM_RETURN_NO_ERROR, NULL,
+        "gl-dmabuf create compute program for %s failed", shaders_info[id].name);
+
+    return shader;
+}
+
+class Impl
+{
+public:
+    explicit Impl (GLDmaBufferHandler *handler);
+    virtual ~Impl ();
+
+    virtual XCamReturn configure_resource (const SmartPtr<ImageHandler::Parameters> &param) = 0;
+    virtual XCamReturn start (const SmartPtr<ImageHandler::Parameters> &param) = 0;
+
+public:
+    void dump_texture_image (const char* prefix, int32_t idx);
+
+protected:
+    GLDmaBufferHandler        *_handler;
+    SmartPtr<GLImageShader>    _shader;
+    SmartPtr<GLTexture>        _texture;
+};
+
+class DmaBufferReader
+    : public Impl
+{
+public:
+    explicit DmaBufferReader (GLDmaBufferHandler *handler);
+    virtual ~DmaBufferReader () {}
+
+    virtual XCamReturn configure_resource (const SmartPtr<ImageHandler::Parameters> &param);
+    virtual XCamReturn start (const SmartPtr<ImageHandler::Parameters> &param);
+};
+
+class DmaBufferWriter
+    : public Impl
+{
+public:
+    explicit DmaBufferWriter (GLDmaBufferHandler *handler);
+    virtual ~DmaBufferWriter () {}
+
+    virtual XCamReturn configure_resource (const SmartPtr<ImageHandler::Parameters> &param);
+    virtual XCamReturn start (const SmartPtr<ImageHandler::Parameters> &param);
+};
+
+Impl::Impl (GLDmaBufferHandler *handler)
+    : _handler (handler)
+{
+}
+
+Impl::~Impl ()
+{
+    _shader.release ();
+    GLTexture::destroy_texture (_texture);
+    _texture.release ();
+}
+
+void
+Impl::dump_texture_image (const char* prefix, int32_t idx)
+{
+    char file_name[256];
+
+    snprintf ( file_name, 256, "%s-texture-%d.yuv", prefix,  idx);
+    _texture->dump_texture_image (file_name);
+}
+
+DmaBufferReader::DmaBufferReader (GLDmaBufferHandler *handler)
+    : Impl (handler)
+{
+}
+
+XCamReturn
+DmaBufferReader::configure_resource (const SmartPtr<ImageHandler::Parameters> &param)
+{
+    _shader = create_shader (CopyTex2SSBO, "shader_copy_tex_to_ssbo");
+    XCAM_ASSERT (_shader.ptr ());
+
+    const VideoBufferInfo &in_info = param->in_buf->get_video_info ();
+    const VideoBufferInfo &out_info = param->out_buf->get_video_info ();
+    XCAM_FAIL_RETURN (
+        ERROR, out_info.width > 0, XCAM_RETURN_ERROR_PARAM,
+        "gl-dmabuf invalid output width: %d", out_info.width);
+
+    XCAM_LOG_DEBUG ("DmaBufferReader input width:%d, height:%d, stride:%d, offset:%d", in_info.width, in_info.height, in_info.strides[0], in_info.offsets[0]);
+    XCAM_LOG_DEBUG ("DmaBufferReader input aligned width:%d, aligned height:%d", in_info.aligned_width, in_info.aligned_height);
+    XCAM_LOG_DEBUG ("DmaBufferReader: modifiers:%lu, dmabuf fd:%d, fourcc:%s", in_info.modifiers[0], param->in_buf->get_fd (), xcam_fourcc_to_string(in_info.fourcc));
+
+    XCAM_LOG_DEBUG ("DmaBufferReader output width:%d, height:%d, stride:%d, offset:%d", out_info.width, out_info.height, out_info.strides[0], in_info.offsets[0]);
+    XCAM_LOG_DEBUG ("DmaBufferReader output aligned width:%d, aligned height:%d", out_info.aligned_width, out_info.aligned_height);
+
+    const size_t uint_bytes = sizeof (uint32_t);
+    uint32_t in_img_width = in_info.aligned_width / uint_bytes;
+    uint32_t in_img_height = in_info.aligned_height * 3 / 2;
+    uint32_t out_img_width = out_info.aligned_width / uint_bytes;
+    uint32_t out_img_height = out_info.aligned_height * 3 / 2;
+
+    GLCmdList cmds;
+    cmds.push_back (new GLCmdUniformT<uint32_t> ("out_img_width", out_img_width));
+    _shader->set_commands (cmds);
+
+    GLGroupsSize groups_size;
+    groups_size.x = XCAM_ALIGN_UP (out_img_width, 8);
+    groups_size.y = XCAM_ALIGN_UP (out_img_height, 8);
+    groups_size.z = 1;
+    XCAM_LOG_DEBUG ("DmaBufferReader set group size: x:%d, y:%d, z:%d", groups_size.x, groups_size.y, groups_size.z);
+
+    _shader->set_groups_size (groups_size);
+
+    return XCAM_RETURN_NO_ERROR;
+}
+
+XCamReturn
+DmaBufferReader::start (const SmartPtr<ImageHandler::Parameters> &param)
+{
+    SmartPtr<VideoBuffer> dma_buf = param->in_buf;
+    SmartPtr<GLBuffer> gl_buf = get_glbuffer (param->out_buf);
+
+    _texture = GLTexture::create_texture (dma_buf);
+    if (!_texture.ptr ()) {
+        return XCAM_RETURN_ERROR_GLES;
+    }
+#if DUMP_TEST
+    _texture->dump_texture_image ("dmabuf_to_shader_input_texture.yuv");
+#endif
+
+    GLCmdList cmds;
+    cmds.push_back (new GLCmdBindTexture (_texture, 0));
+    cmds.push_back (new GLCmdBindBufRange (gl_buf, 1));
+    _shader->set_commands (cmds);
+
+    return _shader->work (NULL);
+}
+
+DmaBufferWriter::DmaBufferWriter (GLDmaBufferHandler *handler)
+    : Impl (handler)
+{
+}
+
+XCamReturn
+DmaBufferWriter::configure_resource (const SmartPtr<ImageHandler::Parameters> &param)
+{
+    _shader = create_shader (CopySSBO2Tex, "shader_copy_ssbo_to_tex");
+    XCAM_ASSERT (_shader.ptr ());
+
+    const VideoBufferInfo &in_info = param->in_buf->get_video_info ();
+    const VideoBufferInfo &out_info = param->out_buf->get_video_info ();
+    XCAM_FAIL_RETURN (
+        ERROR, out_info.width > 0, XCAM_RETURN_ERROR_PARAM,
+        "gl-dmabuf invalid output width: %d", out_info.width);
+
+    const size_t uint_bytes = sizeof (uint32_t);
+    uint32_t in_img_width = in_info.aligned_width / uint_bytes;
+    uint32_t in_img_height = in_info.aligned_height * 3 / 2;
+    uint32_t out_img_width = out_info.aligned_width / uint_bytes;
+    uint32_t out_img_height = out_info.aligned_height * 3 / 2;
+
+    XCAM_LOG_DEBUG ("DmaBufferWriter shader input width:%d, height:%d", in_img_width, in_img_height);
+    XCAM_LOG_DEBUG ("DmaBufferWriter shader output width:%d, height:%d", out_img_width, out_img_height);
+
+    GLCmdList cmds;
+    cmds.push_back (new GLCmdUniformT<uint32_t> ("in_img_width", in_img_width));
+    _shader->set_commands (cmds);
+
+    GLGroupsSize groups_size;
+    groups_size.x = XCAM_ALIGN_UP (in_img_width, 8);
+    groups_size.y = XCAM_ALIGN_UP (in_img_height, 8);
+    groups_size.z = 1;
+    _shader->set_groups_size (groups_size);
+
+    return XCAM_RETURN_NO_ERROR;
+}
+
+XCamReturn
+DmaBufferWriter::start (const SmartPtr<ImageHandler::Parameters> &param)
+{
+    SmartPtr<GLBuffer> gl_buf = get_glbuffer (param->in_buf);
+
+    SmartPtr<VideoBuffer> dma_buf = param->out_buf;
+    _texture = GLTexture::create_texture (dma_buf);
+    if (!_texture.ptr ()) {
+        return XCAM_RETURN_ERROR_GLES;
+    }
+
+    GLCmdList cmds;
+    cmds.push_back (new GLCmdBindBufRange (gl_buf, 0));
+    cmds.push_back (new GLCmdBindTexture (_texture, 1));
+
+    _shader->set_commands (cmds);
+
+    return _shader->work (NULL);
+}
+
+} //GLDmaBufferPriv
+
+GLDmaBufferHandler::GLDmaBufferHandler (const char *name)
+    : GLImageHandler (name)
+{
+    _opt_type = CopyTex2SSBO;
+}
+
+GLDmaBufferHandler::~GLDmaBufferHandler ()
+{
+    terminate ();
+}
+
+XCamReturn
+GLDmaBufferHandler::set_opt_type (const uint32_t type)
+{
+    _opt_type = type;
+
+    return XCAM_RETURN_NO_ERROR;
+}
+
+XCamReturn
+GLDmaBufferHandler::configure_resource (const SmartPtr<Parameters> &param)
+{
+    XCAM_ASSERT (param.ptr () && param->in_buf.ptr ());
+    XCamReturn ret = XCAM_RETURN_NO_ERROR;
+
+    SmartPtr<GLDmaBufferPriv::Impl> impl;
+    switch (_opt_type) {
+    case CopyTex2SSBO:
+        impl = new GLDmaBufferPriv::DmaBufferReader (this);
+        break;
+    case CopySSBO2Tex:
+        impl = new GLDmaBufferPriv::DmaBufferWriter (this);
+        break;
+    }
+    XCAM_ASSERT (impl.ptr ());
+
+    ret = impl->configure_resource (param);
+    XCAM_FAIL_RETURN (
+        ERROR, ret == XCAM_RETURN_NO_ERROR, ret,
+        "gl-dmabuf configure resource failed");
+
+    _impl = impl;
+    return ret;
+}
+
+XCamReturn
+GLDmaBufferHandler::start_work (const SmartPtr<ImageHandler::Parameters> &param)
+{
+    return _impl->start (param);
+};
+
+XCamReturn
+GLDmaBufferHandler::terminate ()
+{
+    if (_impl.ptr ()) {
+        _impl.release ();
+    }
+
+    return GLImageHandler::terminate ();
+}
+
+XCamReturn
+GLDmaBufferHandler::read_dma_buffer (const SmartPtr<DmaVideoBuffer> &dma_buf, SmartPtr<VideoBuffer> &out_buf)
+{
+    XCAM_ASSERT (dma_buf.ptr ());
+    XCAM_ASSERT (out_buf.ptr ());
+
+    XCamReturn ret;
+    SmartPtr<ImageHandler::Parameters> param = new ImageHandler::Parameters (dma_buf, out_buf);
+    XCAM_ASSERT (param.ptr ());
+
+    SmartPtr<GLDmaBufferPriv::Impl> impl = new GLDmaBufferPriv::DmaBufferReader (this);
+    XCAM_ASSERT (impl.ptr ());
+
+    ret = impl->configure_resource (param);
+    XCAM_FAIL_RETURN (
+        ERROR, ret == XCAM_RETURN_NO_ERROR, ret,
+        "gl-dmabuf reader configure resource failed");
+
+    ret = impl->start (param);
+    XCAM_FAIL_RETURN (ERROR, xcam_ret_is_ok (ret), ret, "gl-dmabuf reader execute failed");
+
+    GLSync::flush ();
+    GLSync::finish ();
+    if (!out_buf.ptr ()) {
+        out_buf = param->out_buf;
+    }
+
+    return ret;
+}
+
+XCamReturn
+GLDmaBufferHandler::write_dma_buffer (const SmartPtr<VideoBuffer> &in_buf, SmartPtr<DmaVideoBuffer> &dma_buf)
+{
+    XCAM_ASSERT (in_buf.ptr ());
+    XCAM_ASSERT (dma_buf.ptr ());
+    XCAM_ASSERT (-1 != dma_buf->get_fd ());
+
+    XCamReturn ret;
+    SmartPtr<ImageHandler::Parameters> param = new ImageHandler::Parameters (in_buf, dma_buf);
+    XCAM_ASSERT (param.ptr ());
+
+    SmartPtr<GLDmaBufferPriv::Impl> impl = new GLDmaBufferPriv::DmaBufferWriter (this);
+    XCAM_ASSERT (impl.ptr ());
+
+    ret = impl->configure_resource (param);
+    XCAM_FAIL_RETURN (
+        ERROR, ret == XCAM_RETURN_NO_ERROR, ret,
+        "gl-dmabuf writer configure resource failed");
+
+    ret = impl->start (param);
+    XCAM_FAIL_RETURN (ERROR, xcam_ret_is_ok (ret), ret, "gl-dmabuf writer execute failed");
+
+    GLSync::flush ();
+    GLSync::finish ();
+
+    return ret;
+}
+
+}

--- a/modules/gles/gl_dma_buffer_handler.h
+++ b/modules/gles/gl_dma_buffer_handler.h
@@ -1,0 +1,68 @@
+/*
+ * gl_dma_buffer_handler.h - gl DMA buffer handler class
+ *
+ *  Copyright (c) 2022 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Zong Wei <wei.zong@intel.com>
+ */
+
+#ifndef XCAM_GL_DMA_BUFFER_HANDER_H
+#define XCAM_GL_DMA_BUFFER_HANDER_H
+
+#include <xcam_utils.h>
+#include <gles/gl_image_shader.h>
+#include <gles/gl_image_handler.h>
+#include <gles/gl_texture.h>
+
+#include <dma_video_buffer.h>
+
+namespace XCam {
+
+namespace GLDmaBufferPriv {
+class Impl;
+}
+
+enum ShaderID {
+    CopyTex2SSBO = 0,
+    CopySSBO2Tex,
+};
+
+class GLDmaBufferHandler
+    : public GLImageHandler
+{
+    friend class GLDmaBufferPriv::Impl;
+
+public:
+    GLDmaBufferHandler (const char *name = "GLDmaBufferHandler");
+    ~GLDmaBufferHandler ();
+
+    XCamReturn set_opt_type (const uint32_t type);
+
+    virtual XCamReturn terminate ();
+
+    XCamReturn read_dma_buffer (const SmartPtr<DmaVideoBuffer> &dma_buf, SmartPtr<VideoBuffer> &out_buf);
+    XCamReturn write_dma_buffer (const SmartPtr<VideoBuffer> &in_buf, SmartPtr<DmaVideoBuffer> &dma_buf);
+
+protected:
+    virtual XCamReturn configure_resource (const SmartPtr<Parameters> &param);
+    virtual XCamReturn start_work (const SmartPtr<Parameters> &param);
+
+private:
+    uint32_t _opt_type;
+    SmartPtr<GLDmaBufferPriv::Impl> _impl;
+};
+
+}
+#endif // XCAM_GL_DMA_BUFFER_HANDER_H

--- a/modules/gles/gl_stitcher.h
+++ b/modules/gles/gl_stitcher.h
@@ -42,10 +42,15 @@ public:
         : ImageHandler::Parameters
     {
         SmartPtr<VideoBuffer> in_bufs[XCAM_STITCH_MAX_CAMERAS];
+        SmartPtr<VideoBuffer> in_dmabufs[XCAM_STITCH_MAX_CAMERAS];
+        SmartPtr<VideoBuffer> out_dmabuf;
+        bool enable_dmabuf;
 
         StitcherParam ()
             : Parameters (NULL, NULL)
-        {}
+        {
+            enable_dmabuf = false;
+        }
     };
 
 public:

--- a/modules/gles/gl_texture.cpp
+++ b/modules/gles/gl_texture.cpp
@@ -1,0 +1,295 @@
+/*
+ * gl_texture.cpp - GL texture
+ *
+ *  Copyright (c) 2022 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Zong Wei <wei.zong@intel.com>
+ */
+
+#include "gl_texture.h"
+#include <gles/egl/egl_utils.h>
+#include <gles/egl/egl_base.h>
+
+#include <dma_video_buffer.h>
+
+namespace XCam {
+
+GLTextureDesc::GLTextureDesc ()
+    : format (V4L2_PIX_FMT_NV12)
+    , width (0)
+    , height (0)
+    , aligned_width (0)
+    , aligned_height (0)
+    , size (0)
+{
+    xcam_mem_clear (strides);
+    xcam_mem_clear (slice_size);
+    xcam_mem_clear (offsets);
+}
+
+GLTexture::GLTexture (uint32_t width, uint32_t height, uint32_t format, GLuint id, GLenum target, GLenum usage)
+    : _width (width)
+    , _height (height)
+    , _format (format)
+    , _texture_id (id)
+    , _target (target)
+    , _usage (usage)
+{
+}
+
+XCamReturn
+GLTexture::bind (uint32_t index)
+{
+    XCAM_UNUSED (index);
+
+    glBindTexture (_target, _texture_id);
+    GLenum error = gl_error ();
+    XCAM_FAIL_RETURN (
+        ERROR, error == GL_NO_ERROR, XCAM_RETURN_ERROR_GLES,
+        "GL bind texture:%d failed, error flag: %s", _texture_id, gl_error_string (error));
+    return XCAM_RETURN_NO_ERROR;
+}
+
+XCamReturn
+GLTexture::bind_image (GLuint index, GLenum access, GLenum format)
+{
+    glBindImageTexture (index, /* unit, note that we're not offsetting GL_TEXTURE0 */
+                        _texture_id, 0, GL_FALSE, 0, access, format);
+    GLenum error = gl_error ();
+    XCAM_FAIL_RETURN (
+        ERROR, error == GL_NO_ERROR, XCAM_RETURN_ERROR_GLES,
+        "GL bind texture:%d failed, error flag: %s", _texture_id, gl_error_string (error));
+    return XCAM_RETURN_NO_ERROR;
+}
+
+GLTexture::~GLTexture ()
+{
+    XCAM_LOG_DEBUG ("GLTexture::~GLTexture");
+    if (_texture_id) {
+        glDeleteTextures (1, &_texture_id);
+
+        GLenum error = gl_error ();
+        if (error != GL_NO_ERROR) {
+            XCAM_LOG_WARNING (
+                "GL Texture delete failed, error flag: %s", gl_error_string (error));
+        }
+    }
+}
+
+SmartPtr<GLTexture>
+GLTexture::create_texture (
+    const GLvoid *data,
+    uint32_t width,
+    uint32_t height,
+    uint32_t format,
+    GLenum target,
+    GLenum usage)
+{
+    XCAM_ASSERT (width > 0);
+    XCAM_ASSERT (height > 0);
+    XCAM_LOG_DEBUG ("GLTexture::create_texture from buffer: width:%d, height:%d, format:%s", width, height, xcam_fourcc_to_string (format));
+
+    if (format != V4L2_PIX_FMT_NV12 && format != V4L2_PIX_FMT_YUV420) {
+        XCAM_LOG_ERROR ("invaild input image format");
+        return NULL;
+    }
+
+    GLenum error;
+    GLuint texture_id = 0;
+    glGenTextures (1, &texture_id);
+    error = gl_error ();
+    XCAM_FAIL_RETURN (
+        ERROR, texture_id && (error == GL_NO_ERROR), NULL,
+        "GL texture creation failed in glGenTextures, error flag: %s", gl_error_string (error));
+
+    glBindTexture (target, texture_id);
+    XCAM_FAIL_RETURN (
+        ERROR, (error = gl_error ()) == GL_NO_ERROR, NULL,
+        "GL texture creation failed in glBindTexture:%d, error flag: %s",
+        texture_id, gl_error_string (error));
+
+    glTexImage2D (target, 0, GL_RED, width, height * 3 / 2, 0, GL_RED, GL_UNSIGNED_BYTE, data);
+    XCAM_FAIL_RETURN (
+        ERROR, (error = gl_error ()) == GL_NO_ERROR, NULL,
+        "GL texture creation failed in glTexImage2D, id:%d, error flag: %s",
+        texture_id, gl_error_string (error));
+
+    glTexParameteri (target, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri (target, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    XCAM_FAIL_RETURN (
+        ERROR, (error = gl_error ()) == GL_NO_ERROR, NULL,
+        "GL texture creation failed in glTexParameteri, id:%d, error flag: %s",
+        texture_id, gl_error_string (error));
+
+    return new GLTexture (width, height, format, texture_id, target, usage);
+}
+
+EGLImage GLTexture::_egl_image;
+
+SmartPtr<GLTexture>
+GLTexture::create_texture (
+    SmartPtr<VideoBuffer> &buf,
+    GLenum target,
+    GLenum usage)
+{
+    SmartPtr<DmaVideoBuffer> dma_buf = buf.dynamic_cast_ptr<DmaVideoBuffer> ();
+    const VideoBufferInfo &info = dma_buf->get_video_info ();
+
+    XCAM_LOG_DEBUG ("GLTexture::create_texture DmaVideoBuffer width:%d, height:%d, stride:%d, offset:%d, format:%s", info.width, info.height, info.strides[0], info.offsets[0], xcam_fourcc_to_string (info.format));
+    XCAM_LOG_DEBUG ("modifiers:%lu, dmabuf fd:%d, fourcc:%s", info.modifiers[0], dma_buf->get_fd (), xcam_fourcc_to_string(info.fourcc));
+
+    SmartPtr<EGLBase> egl_base = EGLBase::instance ();
+
+    int dmabuf_fd = dma_buf->get_fd ();
+    uint32_t width = info.width;
+    uint32_t height = info.height;
+    uint32_t format = info.format;
+    uint32_t strides = info.strides[0];
+    uint32_t offsets = info.offsets[0];
+    uint64_t modifiers = info.modifiers[0];
+    uint32_t fourcc = info.fourcc;
+
+    GLuint texture_id = 0;
+    if (false == egl_base->destroy_image (_egl_image)) {
+        //XCAM_LOG_WARNING ("destroy egl image failed!");
+    }
+    _egl_image = egl_base->create_image (
+                     dmabuf_fd,
+                     modifiers,
+                     width,
+                     height * 3 / 2,
+                     strides,
+                     offsets,
+                     fourcc);
+
+    XCAM_ASSERT (_egl_image != EGL_NO_IMAGE);
+
+    glGenTextures (1, &texture_id);
+    GLenum error = gl_error ();
+    XCAM_FAIL_RETURN (
+        ERROR, texture_id && (error == GL_NO_ERROR), NULL,
+        "GL texture creation failed, error flag: %s", gl_error_string (error));
+
+    glActiveTexture (GL_TEXTURE0);
+    XCAM_FAIL_RETURN (
+        ERROR, (error = gl_error ()) == GL_NO_ERROR, NULL,
+        "GL texture active failed when bind texture:%d, error flag: %s",
+        texture_id, gl_error_string (error));
+
+    glBindTexture (target, texture_id);
+    XCAM_FAIL_RETURN (
+        ERROR, (error = gl_error ()) == GL_NO_ERROR, NULL,
+        "GL texture creation failed when bind texture:%d, error flag: %s",
+        texture_id, gl_error_string (error));
+
+    PFNGLEGLIMAGETARGETTEXTURE2DOESPROC glEGLImageTargetTexture2DOES =
+        (PFNGLEGLIMAGETARGETTEXTURE2DOESPROC)eglGetProcAddress ("glEGLImageTargetTexture2DOES");
+
+    glEGLImageTargetTexture2DOES (target, _egl_image);
+    XCAM_FAIL_RETURN (
+        ERROR, (error = gl_error ()) == GL_NO_ERROR, NULL,
+        "EGL image target texture2D:%d, error flag: %s",
+        texture_id, gl_error_string (error));
+
+    glTexParameteri (target, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    XCAM_FAIL_RETURN (
+        ERROR, (error = gl_error ()) == GL_NO_ERROR, NULL,
+        "GL texture parameter:%d, error flag: %s",
+        texture_id, gl_error_string (error));
+
+    glTexParameteri (target, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    XCAM_FAIL_RETURN (
+        ERROR, (error = gl_error ()) == GL_NO_ERROR, NULL,
+        "GL texture parameter:%d, error flag: %s",
+        texture_id, gl_error_string (error));
+
+    return new GLTexture (width, height, format, texture_id, target, usage);
+}
+
+XCamReturn
+GLTexture::destroy_texture (SmartPtr<GLTexture>& tex)
+{
+    if (tex.ptr ()) {
+        tex.release ();
+    }
+
+    SmartPtr<EGLBase> egl_base = EGLBase::instance ();
+
+    if (false == egl_base->destroy_image (_egl_image)) {
+        XCAM_LOG_WARNING ("destroy egl image failed!");
+        return XCAM_RETURN_ERROR_EGL;
+    }
+
+    return XCAM_RETURN_NO_ERROR;
+}
+
+void
+GLTexture::dump_texture_image (const char *file_name)
+{
+    uint32_t width = get_width ();
+    uint32_t height = get_height ();
+    uint32_t format = get_format ();
+
+    uint8_t* texture_data = NULL;
+    if (V4L2_PIX_FMT_NV12 == format) {
+        texture_data = new uint8_t [width * height * 3 / 2];
+    }
+    XCAM_LOG_DEBUG ("image width:%d, height:%d, format:%s", width, height, xcam_fourcc_to_string (format));
+
+    glActiveTexture (GL_TEXTURE0);
+    GLenum error = gl_error ();
+    if (error != GL_NO_ERROR) {
+        XCAM_LOG_ERROR ("Error glActiveTexture, id:%d, error flag: %s", _texture_id, gl_error_string (error));
+    }
+
+    glBindTexture (_target, _texture_id);
+    error = gl_error ();
+    if (error != GL_NO_ERROR) {
+        XCAM_LOG_ERROR ("Error glBindTexture, id:%d, error flag: %s", _texture_id, gl_error_string (error));
+    }
+
+    GLuint fbo_id;
+    glGenFramebuffers (1, &fbo_id);
+    error = gl_error ();
+    if (error != GL_NO_ERROR) {
+        XCAM_LOG_ERROR ("Error glGenFramebuffers, id:%d, error flag: %s", _texture_id, gl_error_string (error));
+    }
+
+    glBindFramebuffer (GL_FRAMEBUFFER, fbo_id);
+    error = gl_error ();
+    if (error != GL_NO_ERROR) {
+        XCAM_LOG_ERROR ("Error glBindFramebuffer, id:%d, error flag: %s", _texture_id, gl_error_string (error));
+    }
+
+    glFramebufferTexture2D (GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, _texture_id, 0);
+    error = gl_error ();
+    if (error != GL_NO_ERROR) {
+        XCAM_LOG_ERROR ("Error glFramebufferTexture2D, id:%d, error flag: %s", _texture_id, gl_error_string (error));
+    }
+
+    glReadPixels (0, 0, width, height * 3 / 2, GL_RED, GL_UNSIGNED_BYTE, texture_data);
+    error = gl_error ();
+    if (error != GL_NO_ERROR) {
+        XCAM_LOG_ERROR ("Error glReadPixels, id:%d, error flag: %s", _texture_id, gl_error_string (error));
+    }
+
+    FILE* fbo_file = fopen (file_name, "wb");
+    fwrite (texture_data, height * width * 3 / 2, 1, fbo_file);
+    fclose (fbo_file);
+    delete [] texture_data;
+}
+
+}
+

--- a/modules/gles/gl_texture.h
+++ b/modules/gles/gl_texture.h
@@ -1,0 +1,113 @@
+/*
+ * gl_texture.h - GL texture
+ *
+ *  Copyright (c) 2022 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Zong Wei <wei.zong@intel.com>
+ */
+
+#ifndef XCAM_GL_TEXTRUE_H
+#define XCAM_GL_TEXTRUE_H
+
+#include <gles/gles_std.h>
+#include <gles/egl/egl_utils.h>
+
+#include <video_buffer.h>
+
+#define XCAM_GL_MAX_COMPONENTS 4
+
+namespace XCam {
+
+struct GLTextureDesc {
+    uint32_t        format;
+    uint32_t        width;
+    uint32_t        height;
+    uint32_t        aligned_width;
+    uint32_t        aligned_height;
+    uint32_t        size;
+    uint32_t        strides[XCAM_GL_MAX_COMPONENTS];
+    uint32_t        offsets[XCAM_GL_MAX_COMPONENTS];
+    uint32_t        slice_size[XCAM_GL_MAX_COMPONENTS];
+
+    GLTextureDesc ();
+};
+
+class GLTexture
+{
+public:
+    ~GLTexture ();
+
+    static SmartPtr<GLTexture> create_texture (
+        const GLvoid *data = NULL,
+        uint32_t width = 0, uint32_t height = 0, uint32_t format = 0,
+        GLenum target = GL_TEXTURE_2D, GLenum usage = GL_STATIC_DRAW);
+
+    static SmartPtr<GLTexture> create_texture (
+        SmartPtr<VideoBuffer> &buf,
+        GLenum target = GL_TEXTURE_2D, GLenum usage = GL_STATIC_DRAW);
+
+    static XCamReturn destroy_texture (SmartPtr<GLTexture>& tex);
+
+    GLuint get_texture_id () const {
+        return _texture_id;
+    }
+    GLenum get_target () const {
+        return _target;
+    }
+    GLenum get_usage () const {
+        return _usage;
+    }
+    uint32_t get_format () const {
+        return _format;
+    }
+    uint32_t get_width () const {
+        return _width;
+    }
+    uint32_t get_height () const {
+        return _height;
+    }
+    void set_texture_desc (const GLTextureDesc &desc) {
+        _desc = desc;
+    }
+    const GLTextureDesc &get_texture_desc () {
+        return _desc;
+    }
+
+    XCamReturn bind (uint32_t index);
+
+    XCamReturn bind_image (GLuint unit, GLenum access = GL_READ_WRITE, GLenum format = GL_R8);
+
+    void dump_texture_image (const char *file_name);
+
+private:
+    explicit GLTexture (uint32_t width, uint32_t height, uint32_t format, GLuint id, GLenum target = GL_TEXTURE_2D, GLenum usage = GL_STATIC_DRAW);
+
+private:
+    XCAM_DEAD_COPY (GLTexture);
+
+private:
+    uint32_t       _width;
+    uint32_t       _height;
+    uint32_t       _format;
+    GLuint         _texture_id;
+    GLenum         _target;
+    GLenum         _usage;
+    GLTextureDesc  _desc;
+    static EGLImage _egl_image;
+};
+
+}
+
+#endif  //XCAM_GL_TEXTURE_H

--- a/shaders/glsl/shader_copy_ssbo_to_tex.comp.sl
+++ b/shaders/glsl/shader_copy_ssbo_to_tex.comp.sl
@@ -1,0 +1,24 @@
+#version 310 es
+
+layout (local_size_x = 1, local_size_y = 1) in;
+
+layout (binding = 0) readonly buffer InBuf {
+    uint data[];
+} in_buf;
+
+layout (binding = 1, rgba8) writeonly uniform highp image2D out_texture;
+
+uniform uint in_img_width;
+
+void main ()
+{
+    uvec2 g_id = gl_GlobalInvocationID.xy;
+
+    vec4 tex = unpackUnorm4x8 (in_buf.data[g_id.y * in_img_width + g_id.x]);
+
+    imageStore (out_texture, ivec2(4u * g_id.x, g_id.y), tex.rrrr);
+    imageStore (out_texture, ivec2(4u * g_id.x + 1u, g_id.y), tex.gggg);
+    imageStore (out_texture, ivec2(4u * g_id.x + 2u, g_id.y), tex.bbbb);
+    imageStore (out_texture, ivec2(4u * g_id.x + 3u, g_id.y), tex.aaaa);
+}
+

--- a/shaders/glsl/shader_copy_tex_to_ssbo.comp.sl
+++ b/shaders/glsl/shader_copy_tex_to_ssbo.comp.sl
@@ -1,0 +1,25 @@
+#version 310 es
+
+layout (local_size_x = 1, local_size_y = 1) in;
+
+layout (binding = 0) uniform sampler2D in_texture;
+layout (binding = 1) writeonly buffer OutBuf {
+    uint data[];
+} out_buf;
+
+uniform uint out_img_width;
+
+void main ()
+{
+    uvec2 g_id = gl_GlobalInvocationID.xy;
+
+    vec4 out1 = texelFetch (in_texture, ivec2(4u * g_id.x, g_id.y), 0);
+    vec4 out2 = texelFetch (in_texture, ivec2(4u * g_id.x + 1u, g_id.y), 0);
+    vec4 out3 = texelFetch (in_texture, ivec2(4u * g_id.x + 2u, g_id.y), 0);
+    vec4 out4 = texelFetch (in_texture, ivec2(4u * g_id.x + 3u, g_id.y), 0);
+
+    vec4 out_pixels = vec4 (out1.r, out2.r, out3.r, out4.r);
+
+    out_buf.data[g_id.y * out_img_width + g_id.x] = packUnorm4x8 (out_pixels);
+}
+

--- a/shaders/glslx/Makefile.am
+++ b/shaders/glslx/Makefile.am
@@ -16,6 +16,8 @@ glslx_sources = \
     shader_fastmap_blend_y.comp.slx          \
     shader_fastmap_blend_uv_nv12.comp.slx    \
     shader_fastmap_blend_uv_yuv420.comp.slx  \
+    shader_copy_tex_to_ssbo.comp.slx         \
+    shader_copy_ssbo_to_tex.comp.slx         \
     $(NULL)
 
 add_quotation_marks_sh = \

--- a/tests/test-render-surround-view.cpp
+++ b/tests/test-render-surround-view.cpp
@@ -685,8 +685,7 @@ int main (int argc, char *argv[])
             XCAM_LOG_WARNING ("GLES module does not support Dual Curve scale mode currently, change to Single Const scale mode");
             scale_mode = ScaleSingleConst;
         }
-        SmartPtr<EGLBase> egl;
-        egl = new EGLBase ();
+        SmartPtr<EGLBase> egl = EGLBase::instance ();
         XCAM_ASSERT (egl.ptr ());
         XCAM_FAIL_RETURN (ERROR, egl->init (), -1, "init EGL failed");
 #else

--- a/tests/test-surround-view.cpp
+++ b/tests/test-surround-view.cpp
@@ -903,7 +903,7 @@ int main (int argc, char *argv[])
             return -1;
         }
 
-        egl = new EGLBase ();
+        egl = EGLBase::instance ();
         XCAM_ASSERT (egl.ptr ());
 
         if (NULL == device_node) {

--- a/xcore/base/xcam_buffer.h
+++ b/xcore/base/xcam_buffer.h
@@ -84,8 +84,10 @@ struct _XCamVideoBufferInfo {
     uint32_t aligned_height;
     uint32_t size;
     uint32_t components;
+    uint32_t fourcc;
     uint32_t strides [XCAM_VIDEO_MAX_COMPONENTS];
     ptrdiff_t offsets [XCAM_VIDEO_MAX_COMPONENTS];
+    uint64_t modifiers [XCAM_VIDEO_MAX_COMPONENTS];
 };
 
 typedef enum {

--- a/xcore/base/xcam_common.h
+++ b/xcore/base/xcam_common.h
@@ -51,6 +51,7 @@ typedef enum {
     XCAM_RETURN_ERROR_ORDER     = -10,
     XCAM_RETURN_ERROR_GLES      = -11,
     XCAM_RETURN_ERROR_VULKAN    = -12,
+    XCAM_RETURN_ERROR_EGL       = -13,
 
     XCAM_RETURN_ERROR_TIMEOUT   = -20,
 

--- a/xcore/video_buffer.cpp
+++ b/xcore/video_buffer.cpp
@@ -40,8 +40,10 @@ VideoBufferInfo::VideoBufferInfo ()
     aligned_height = 0;
     size = 0;
     components  = 0;
+    fourcc = 0;
     xcam_mem_clear (strides);
     xcam_mem_clear (offsets);
+    xcam_mem_clear (modifiers);
 }
 
 bool
@@ -69,9 +71,11 @@ VideoBufferInfo::fill (const XCamVideoBufferInfo &info)
     aligned_height = info.aligned_height;
     size = info.size;
     components = info.components;
+    fourcc = info.fourcc;
     for (int i = 0; i < XCAM_VIDEO_MAX_COMPONENTS; i++) {
         strides[i] = info.strides[i];
         offsets[i] = info.offsets[i];
+        modifiers[i] = info.modifiers[i];
     }
 
     return true;

--- a/xcore/xcam_utils.cpp
+++ b/xcore/xcam_utils.cpp
@@ -281,7 +281,7 @@ get_gauss_table (uint32_t radius, float sigma, std::vector<float> &table, bool n
 }
 
 void
-dump_buf_perfix_path (const SmartPtr<VideoBuffer> buf, const char *prefix_name)
+dump_buf_perfix_path (const SmartPtr<VideoBuffer> buf, const char *prefix_name, const uint32_t idx)
 {
     char file_name[256];
     XCAM_ASSERT (prefix_name);
@@ -289,8 +289,8 @@ dump_buf_perfix_path (const SmartPtr<VideoBuffer> buf, const char *prefix_name)
 
     const VideoBufferInfo &info = buf->get_video_info ();
     snprintf (
-        file_name, 256, "%s-%dx%d.%s.yuv",
-        prefix_name, info.width, info.height, xcam_fourcc_to_string (info.format));
+        file_name, 256, "%s-%dx%d.%d.%s.yuv",
+        prefix_name, info.width, info.height, idx, xcam_fourcc_to_string (info.format));
 
     dump_video_buf (buf, file_name);
 }

--- a/xcore/xcam_utils.h
+++ b/xcore/xcam_utils.h
@@ -60,7 +60,7 @@ void get_gauss_table (
     uint32_t radius, float sigma, std::vector<float> &table, bool normalize = true);
 
 class VideoBuffer;
-void dump_buf_perfix_path (const SmartPtr<VideoBuffer> buf, const char *prefix_name);
+void dump_buf_perfix_path (const SmartPtr<VideoBuffer> buf, const char *prefix_name, const uint32_t idx = 0);
 bool dump_video_buf (const SmartPtr<VideoBuffer> buf, const char *file_name);
 bool dump_data_buf (const void *buf, const size_t &size, const char *file_name);
 


### PR DESCRIPTION
DMA buffer import & export can be benefit to decoding, stitching and encoding GPU pipeline.
The processed frames passing in E2E pipeline (decoding, stitching and encoding) can be always in GPU memory. This will avoid to memory copy between CPU & GPU.