### PR TITLE
robust: use 'image_width>0U' in test-pipe-manager.cpp L411 and 'frame…

### DIFF
--- a/tests/test-device-manager.cpp
+++ b/tests/test-device-manager.cpp
@@ -846,7 +846,7 @@ int main (int argc, char *argv[])
         cl_post_processor->set_image_warp (image_warp_type);
         if (smart_analyzer.ptr () && (wireframe_type || image_warp_type)) {
             cl_post_processor->set_scaler (true);
-            if (frame_width > 0) {
+            if (frame_width > 0U) {
                 cl_post_processor->set_scaler_factor (640.0 / frame_width);
 	    } else {
                 XCAM_LOG_ERROR ("frame_width can not be zero .");

--- a/tests/test-pipe-manager.cpp
+++ b/tests/test-pipe-manager.cpp
@@ -408,7 +408,7 @@ int main (int argc, char *argv[])
     cl_post_processor->set_image_warp (enable_image_warp);
     if (smart_analyzer.ptr () && (enable_wireframe || enable_image_warp)) {
         cl_post_processor->set_scaler (true);
-	if (image_width > 0) {
+	if (image_width > 0U) {
             cl_post_processor->set_scaler_factor (640.0 / image_width);
 	} else {
             XCAM_LOG_ERROR ("image_width can not be zero .");


### PR DESCRIPTION
…_width>0U' in test-device-manager.cpp L849