### PR TITLE
os-upgrade: ocl header file backward compatibility

### DIFF
--- a/modules/ocl/cl_memory.h
+++ b/modules/ocl/cl_memory.h
@@ -21,6 +21,8 @@
 #ifndef XCAM_CL_MEMORY_H
 #define XCAM_CL_MEMORY_H
 
+#include <CL/cl_gl.h>
+
 #include "ocl/cl_context.h"
 #include "ocl/cl_event.h"
 #include "video_buffer.h"


### PR DESCRIPTION
  Ubuntu 24.04 integrated OpenCL v3.0.15, this release includes several changes that affect backward compatibility:
  "The CL_UNORM_INT24 enums are now properly considered extension enums for all OpenCL versions,
  so applications will need to include an extension header to access this functionality."